### PR TITLE
Fixes "onComplete" callback option name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can also pass an options object into `executeSpecs`
       specs: ['specDir/mySpec1.js', 'specDir/mySpec2.js'],
       // A function to call on completion.
       // function(runner, log)
-      done: function(runner, log) { util.prints('done!'); },
+      onComplete: function(runner, log) { util.prints('done!'); },
       // If true, display spec names.
       isVerbose: false,
       // If true, print colors to the terminal.


### PR DESCRIPTION
This is apparently not named "done". From index.js:

``` javascript
var done = options['onComplete'];
```

Which appears to work for me in my usage.
