### PR TITLE
Catch loading errors in specs, including syntax errors, and report them as failures during test execution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,6 @@ function removeJasmineFrames(text) {
   return lines.join('\n');
 }
 
-var jasmineEnv = jasmine.getEnv();
 var specFiles = [];
 
 /**
@@ -62,7 +61,7 @@ exports.addSpecs = function(specs) {
 /**
  * Alias for jasmine.getEnv().addReporter
  */
-exports.addReporter = jasmineEnv.addReporter;
+exports.addReporter = jasmine.getEnv().addReporter;
 
 /**
  * Execute the loaded specs. Optional options object described below.
@@ -83,6 +82,8 @@ exports.executeSpecs = function(options) {
   var includeStackTrace = options['includeStackTrace'];
   // Time to wait in milliseconds before a test automatically fails
   var defaultTimeoutInterval = options['defaultTimeoutInterval'] || 5000;
+  // Jasmine environment to use.
+  var jasmineEnv = options['jasmineEnv'] || jasmine.getEnv();
 
   if (isVerbose) {
     jasmineEnv.addReporter(new jasmine.TerminalVerboseReporter({
@@ -105,12 +106,16 @@ exports.executeSpecs = function(options) {
 
   for (var i = 0, len = specFiles.length; i < len; ++i) {
     var filename = specFiles[i];
-    // Catch exceptions in loading the spec files.
+    // Catch exceptions in loading the spec files, and make them jasmine test
+    // failures.
     try {
       require(path.resolve(process.cwd(), filename));
     } catch (e) {
-      console.log("Exception loading: " + filename);
-      console.log(e);
+      // Generate a synthetic suite with a failure spec, so that the failure is
+      // reported with other results.
+      jasmineEnv.describe('Exception loading: ' + filename, function() {
+        jasmineEnv.it('Error', function() { throw e; });
+      });
     }
   }
 

--- a/spec/syntax-error_spec.js
+++ b/spec/syntax-error_spec.js
@@ -1,0 +1,21 @@
+var minijasminelib = require('../lib/index');
+
+describe('syntax-error', function() {
+  var env;
+  beforeEach(function() {
+    env = new jasmine.Env();
+    // Hide the failure result on the console
+    env.addReporter = function() {};
+  });
+
+  it('should report a failure when a syntax error happens', function() {
+    minijasminelib.executeSpecs({
+      specs: ['spec/syntax_error.js'],
+      jasmineEnv: env
+    });
+    expect(env.currentRunner().results().failedCount).toEqual(1);
+    var firstResult = env.currentRunner().results().getItems()[0];
+    var firstSpecResult = firstResult.getItems()[0].getItems()[0];
+    expect(firstSpecResult.message).toMatch('SyntaxError');
+  });
+});

--- a/spec/syntax_error.js
+++ b/spec/syntax_error.js
@@ -1,5 +1,5 @@
 describe('Syntax error (THIS IS EXPECTED)', function() {
   it('Syntax error (THIS IS EXPECTED)', function() {
-     }}}}} // syntax error here
+     ) // Syntax error here (THIS IS EXPECTED)
   });
 });

--- a/spec/syntax_error.js
+++ b/spec/syntax_error.js
@@ -1,0 +1,5 @@
+describe('Syntax error (THIS IS EXPECTED)', function() {
+  it('Syntax error (THIS IS EXPECTED)', function() {
+     }}}}} // syntax error here
+  });
+});

--- a/specs.sh
+++ b/specs.sh
@@ -6,12 +6,12 @@ echo "All these tests should pass"
 command="${entry} spec/*_spec.js"
 echo $command
 time $command #/nested/uber-nested
-echo -e "\033[1;35m--- Should have 53, 98 assertions, 0 failures. ---\033[0m"
+echo -e "\033[1;35m--- Should have 54, 100 assertions, 0 failures. ---\033[0m"
 echo ""
 
 echo "These should be examples of failing tests"
-command="${entry} spec/failure_egs.js"
+command="${entry} spec/failure_egs.js spec/syntax_error.js"
 echo $command
 time $command #/nested/uber-nested
-echo -e "\033[1;35m--- Should have 5 tests, 5 assertions, 4 failures ---\033[0m"
+echo -e "\033[1;35m--- Should have 6 tests, 6 assertions, 5 failures ---\033[0m"
 echo ""


### PR DESCRIPTION
Currently errors when loading specs, including javascript syntax errors, result in passing tests in the test runner, which isn't ideal.

There is a try/catch in lib/index.js, so assuming you want other specs to run when some specs have errors in loading?

In this change I create a new describe/it to represent the failure when loading the spec.

An alternative change would be to remove the try/catch or re-throw the exception.
