### PR TITLE
Added option to override terminal reporters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,16 +84,18 @@ exports.executeSpecs = function(options) {
   var defaultTimeoutInterval = options['defaultTimeoutInterval'] || 5000;
   // Jasmine environment to use.
   var jasmineEnv = options['jasmineEnv'] || jasmine.getEnv();
+  // Overrides the print function of the terminal reporters
+  var print = options['print'] || util.print;
 
   if (isVerbose) {
     jasmineEnv.addReporter(new jasmine.TerminalVerboseReporter({
-      print:       util.print,
+      print:       print,
       color:       showColors,
       onComplete:  done,
       stackFilter: removeJasmineFrames}));
   } else {
     jasmineEnv.addReporter(new jasmine.TerminalReporter({
-      print:       util.print,
+      print:       print,
       color: showColors,
       includeStackTrace: includeStackTrace,
       onComplete:  done,


### PR DESCRIPTION
With this extension it is possible to have terminal reporters to write to something else than process.stdout.
I do require this, because I call node from a separate process and would like to capture the output and report back to the calling process.

Since I do also read stdout and stderr from the calling process this would interfer with my process-bridge.
