### PR TITLE
Make jasmine re-initializable by cloning rather than copying into node's global name-space

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,22 @@ var util = require('util'),
     fs  = require('fs');
 
 var minijasminelib = require('./index');
+
+/**
+ * Meta-test
+ * re-initialize jasmine
+ */
+
+jasmine.testValue = 5;
+
+minijasminelib.initialize();
+
+global['minijasminelib'] = minijasminelib;
+
+if(jasmine.testValue == 5) {
+  console.log("---------\nre-initialization test failed!!\n--------");
+}
+
 /**
  * A super simple wrapper around minijasminelib.executeSpecs()
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,31 +1,43 @@
 var util = require('util');
 var path = require('path');
 
+
+
 // Put jasmine in the global context, this is somewhat like running in a
 // browser where every file will have access to `jasmine`.
 var requireJasmine = require('./jasmine-1.3.1.js');
-for (var key in requireJasmine) {
-  global[key] = requireJasmine[key];
-}
+var clone = require('node-v8-clone').clone;
 
-// Overwriting it allows us to handle custom async specs.
-global.it = function(desc, func, timeout) {
-    return jasmine.getEnv().it(desc, func, timeout);
-};
-global.beforeEach = function(func, timeout) {
-    return jasmine.getEnv().beforeEach(func, timeout);
-};
-global.afterEach = function(func, timeout) {
-    return jasmine.getEnv().afterEach(func, timeout);
+var initialize = function() {
+
+  for (var key in requireJasmine) {
+    global[key] = clone(requireJasmine[key], true);
+  }
+
+  // Overwriting it allows us to handle custom async specs.
+  global.it = function(desc, func, timeout) {
+      return jasmine.getEnv().it(desc, func, timeout);
+  };
+  global.beforeEach = function(func, timeout) {
+      return jasmine.getEnv().beforeEach(func, timeout);
+  };
+  global.afterEach = function(func, timeout) {
+      return jasmine.getEnv().afterEach(func, timeout);
+  };
+
+  // Allow async tests by passing in a 'done' function.
+  require('./async-callback');
+
+  // For the terminal reporters.
+  var nodeReporters = require('./reporter').jasmineNode;
+
+  jasmine.TerminalVerboseReporter = nodeReporters.TerminalVerboseReporter;
+  jasmine.TerminalReporter = nodeReporters.TerminalReporter;
 };
 
-// Allow async tests by passing in a 'done' function.
-require('./async-callback');
+initialize();
 
-// For the terminal reporters.
-var nodeReporters = require('./reporter').jasmineNode;
-jasmine.TerminalVerboseReporter = nodeReporters.TerminalVerboseReporter;
-jasmine.TerminalReporter = nodeReporters.TerminalReporter;
+exports.initialize = initialize;
 
 function removeJasmineFrames(text) {
   if (!text) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "licenses": [
     "MIT"
   ],
-  "dependencies": {},
+  "dependencies": {"node-v8-clone": "~0.4.5"},
   "main": "lib/index.js",
   "bin": "bin/minijn",
   "scripts": {


### PR DESCRIPTION
This is useful in continuous testing environments, such as under gulp-jasmine

Currently, running gulp-node, which depends upon minijasminenode, with the following config results in subsequent spec executions appending results to the previous output, so a single test will result in an exponential increase in results and counts.  This also suggests leaky tests could leave artifacts around to affect subsequent executions.  This change allows one to reset jasmine to its initial state before execution of specs.  (Sorry about the odd meta-test - couldn't come up with a simple, more elegant way without significantly changing or duplicating cli.js)

sample gulp config:

var gulp = require('gulp'),
   jasmine = require('gulp-jasmine')
gulp.task('jasmine', function () {
    gulp.src(testFiles)
        .pipe(jasmine());
});
gulp.task('default', function() {
  gulp.watch(testFiles, ['jasmine'])
});

Signed-off-by: Jason Van Pelt jasonpvp@gmail.com
