### PR TITLE
adds because() clause

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,11 +74,11 @@ exports.executeSpecs = function(options) {
   var specs = options['specs'] || [];
   // A function to call on completion. function(runner, log)
   var done = options['onComplete'];
-  // If true, display spec names 
+  // If true, display spec names
   var isVerbose = options['isVerbose'];
-  // If true, print colors to the terminal 
+  // If true, print colors to the terminal
   var showColors = options['showColors'];
-  // If true, include stack traces in failures 
+  // If true, include stack traces in failures
   var includeStackTrace = options['includeStackTrace'];
   // Time to wait in milliseconds before a test automatically fails
   var defaultTimeoutInterval = options['defaultTimeoutInterval'] || 5000;
@@ -88,6 +88,12 @@ exports.executeSpecs = function(options) {
   var print = options['print'] || util.print;
   // Overrides the stack trace filter
   var stackFilter = options['stackFilter'] || removeJasmineFrames;
+
+  var originalGetEnv = jasmine.getEnv;
+  jasmine.getEnv = function() {
+    return jasmineEnv;
+  }
+
 
   if (isVerbose) {
     jasmineEnv.addReporter(new jasmine.TerminalVerboseReporter({
@@ -124,4 +130,6 @@ exports.executeSpecs = function(options) {
   }
 
   jasmineEnv.execute();
+
+  jasmineEnv.getEnv = originalGetEnv;
 };

--- a/lib/jasmine-1.3.1.js
+++ b/lib/jasmine-1.3.1.js
@@ -576,6 +576,12 @@ var expect = function(actual) {
 };
 if (isCommonJS) exports.expect = expect;
 
+var because = function(msg) {
+  var spec = jasmine.getEnv().currentSpec;
+  return new jasmine.BecauseWrapper(msg);
+}
+if (isCommonJS) exports.because = because;
+
 /**
  * Defines part of a jasmine spec.  Used in cominbination with waits or waitsFor in asynchrnous specs.
  *
@@ -1315,6 +1321,7 @@ jasmine.Matchers.matcherFn_ = function(matcherName, matcherFunction) {
       result = !result;
     }
 
+    var spec = jasmine.getEnv().currentSpec;
     if (this.reportWasCalled_) return result;
 
     var message;
@@ -1336,6 +1343,9 @@ jasmine.Matchers.matcherFn_ = function(matcherName, matcherFunction) {
         message += ".";
       }
     }
+    if (this.becauseMsg) {
+      message = this.becauseMsg + ':' + message;
+    }
     var expectationResult = new jasmine.ExpectationResult({
       matcherName: matcherName,
       passed: result,
@@ -1347,7 +1357,6 @@ jasmine.Matchers.matcherFn_ = function(matcherName, matcherFunction) {
     return jasmine.undefined;
   };
 };
-
 
 
 
@@ -2376,6 +2385,19 @@ jasmine.Spec.prototype.expect = function(actual) {
   positive.not = new (this.getMatchersClass_())(this.env, actual, this, true);
   return positive;
 };
+
+
+jasmine.BecauseWrapper = function(msg) {
+  this.becauseMsg = msg;
+};
+
+jasmine.BecauseWrapper.prototype.expect = function(actual) {
+  var spec = jasmine.getEnv().currentSpec;
+  var expectation = jasmine.getEnv().currentSpec.expect(actual);
+  expectation.becauseMsg = this.becauseMsg;
+  expectation.not.becauseMsg = this.becauseMsg;
+  return expectation;
+}
 
 /**
  * Waits a fixed time period before moving to the next block.

--- a/spec/because.js
+++ b/spec/because.js
@@ -1,0 +1,42 @@
+describe('because', function() {
+  // test every functon that sets .message,
+  // and ensure that .not still works....
+  it('fails with 1 error, \'second:Expected \'blue\' to be \'red.\'',
+      function() {
+    var expected = 'blue';
+    because('first').expect(expected).toBe('blue');
+    because('second').expect(expected).toBe('red');
+  });
+
+  it('fails with 1 error, \'second:Expected 4 to be NaN.\'',
+      function() {
+    because('first').expect(4).not.toBeNaN();
+    because('second').expect(4).toBeNaN();
+  });
+
+  it('fails with 1 error, \'second:Expected function to throw an exception.\'',
+      function() {
+    var emptyFunc = function() {};
+    because('first').expect(
+        function() { throw new Error('die'); }).toThrow();
+    because('second').expect(emptyFunc).toThrow();
+  });
+
+  it('fails with 1 error, \'second:Expected false to be truthy\'',
+      function() {
+    because('first').expect(true).toBeTruthy();
+    because('second').expect(false).toBeTruthy();
+  });
+
+  it('fails with 1 error, \'second:Expected 0 to equal 3.\'',
+      function() {
+    because('first').expect('first'.indexOf('s')).toEqual(3);
+    because('second').expect('second'.indexOf('s')).toEqual(3);
+  });
+
+  it('fails with 1 error, \'second:Expected true to be falsy.\'',
+      function() {
+    because('first').expect(false).toBeFalsy();
+    because('second').expect(true).toBeFalsy();
+  });
+});

--- a/specs.sh
+++ b/specs.sh
@@ -2,6 +2,11 @@
 
 entry="node lib/cli.js"
 
+#command="${entry} spec/because2.js"
+#echo $command
+#time $command
+#exit
+
 echo "All these tests should pass"
 command="${entry} spec/*_spec.js"
 echo $command
@@ -10,8 +15,8 @@ echo -e "\033[1;35m--- Should have 54, 100 assertions, 0 failures. ---\033[0m"
 echo ""
 
 echo "These should be examples of failing tests"
-command="${entry} spec/failure_egs.js spec/syntax_error.js"
+command="${entry} spec/because.js spec/failure_egs.js spec/syntax_error.js"
 echo $command
 time $command #/nested/uber-nested
-echo -e "\033[1;35m--- Should have 6 tests, 6 assertions, 5 failures ---\033[0m"
+echo -e "\033[1;35m--- Should have 12 tests, 18 assertions, 11 failures ---\033[0m"
 echo ""


### PR DESCRIPTION
This adds custom error message capability. The usage is that you can do
because(whatever).expect(a).toBe(b)

if the expectation fails, then 'whatever' is prepended to the error message. This is handy when trying to disambiguate between varying error messages, or unclear ones. For example,
because(string1).expect(string1.indexOf('x')).toEqual(-1)
would now print string 1, instead of just saying "expected 3 to equal -1"
