### PR TITLE
Fix for issue #12

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,9 @@ exports.addSpecs = function(specs) {
 /**
  * Alias for jasmine.getEnv().addReporter
  */
-exports.addReporter = jasmine.getEnv().addReporter;
+exports.addReporter = function (reporter) {
+  jasmine.getEnv().addReporter(reporter);
+};
 
 /**
  * Execute the loaded specs. Optional options object described below.


### PR DESCRIPTION
When invoking addReporter for your module, the following error is reported: `Cannot call method 'addReporter' of undefined`. This is because addReporter is only an alias for the function definition and not the encapsulating object environment.
