### PR TITLE
Update to Jasmine 2.1.3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,7 @@
 var util = require('util');
 var path = require('path');
 
-// NOTE: this is really janky but a main function will be added in the next 2.x.x release
-var jasmineRequire = require('../node_modules/jasmine-core/lib/jasmine-core/jasmine.js');
+var jasmineRequire = require('jasmine-core');
 var TerminalReporter = require('./reporter.js').TerminalReporter;
 
 global.jasmine = jasmineRequire.core(jasmineRequire);
@@ -18,20 +17,36 @@ var jasmineInterface = {
     return jasmine.getEnv().xdescribe(description, specDefinitions);
   },
 
-  it: function(desc, func) {
-    return jasmine.getEnv().it(desc, func);
+  fdescribe: function(description, specDefinitions) {
+    return jasmine.getEnv().fdescribe(description, specDefinitions);
   },
 
-  xit: function(desc, func) {
-    return jasmine.getEnv().xit(desc, func);
+  it: function(desc, func, timeout) {
+    return jasmine.getEnv().it(desc, func, timeout);
   },
 
-  beforeEach: function(beforeEachFunction) {
+  xit: function(desc, func, timeout) {
+    return jasmine.getEnv().xit(desc, func, timeout);
+  },
+
+  fit: function(desc, func, timeout) {
+    return jasmine.getEnv().fit(desc, func, timeout);
+  },
+
+  beforeEach: function(beforeEachFunction, timeout) {
     return jasmine.getEnv().beforeEach(beforeEachFunction);
   },
 
-  afterEach: function(afterEachFunction) {
+  afterEach: function(afterEachFunction, timeout) {
     return jasmine.getEnv().afterEach(afterEachFunction);
+  },
+
+  beforeAll: function(beforeAllFunction, timeout) {
+    return jasmine.getEnv().beforeAll(beforeAllFunction);
+  },
+
+  afterAll: function(afterAllFunction, timeout) {
+    return jasmine.getEnv().afterAll(afterAllFunction);
   },
 
   expect: function(actual) {
@@ -40,6 +55,10 @@ var jasmineInterface = {
 
   pending: function() {
     return jasmine.getEnv().pending();
+  },
+
+  fail: function(error) {
+    return jasmine.getEnv().fail(error);
   },
 
   spyOn: function(obj, methodName) {
@@ -84,37 +103,10 @@ jasmine.clock = function() {
 };
 
 /*
- * Support 'it.only', 'fit', 'oit' and 'iit', and equivalent describe focusing.
- * Focused specs trump focused suites.
+ * Support 'it.only', 'oit' and 'iit', and equivalent describe focusing.
  */
-var focusedSuites = [],
-    focusedSpecs = [];
-var focusedSuite = function(description, specDefinitions) {
-  var suite = jasmine.getEnv().describe(description, specDefinitions);
-
-  focusedSuites.push(suite.id);
-  return suite;
-};
-
-var focusedSpec = function(description, func) {
-  var spec = jasmine.getEnv().it(description, func);
-  focusedSpecs.push(spec.id);
-
-  return spec;
-};
-
-describe.only = global.fdescribe = global.ddescribe = global.odescribe = focusedSuite;
-it.only = global.fit = global.iit = global.oit = focusedSpec;
-
-var executionFilter = function(specsToRun) {
-  if (focusedSpecs.length) {
-    return focusedSpecs;
-  } else if (focusedSuites.length) {
-    return focusedSuites;
-  } else {
-    return specsToRun;
-  }
-};
+describe.only = global.ddescribe = global.odescribe = global.fdescribe;
+it.only = global.iit = global.oit = global.fit;
 
 function removeJasmineFrames(text) {
   if (!text) {
@@ -220,6 +212,5 @@ exports.executeSpecs = function(options) {
     }
   }
 
-  var runnablesToRun = executionFilter([jasmine.getEnv().topSuite().id]);
-  jasmine.getEnv().execute(runnablesToRun);
+  jasmine.getEnv().execute();
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "MIT"
   ],
   "dependencies": {
-    "jasmine-core": "2.0.0"
+    "jasmine-core": "2.1.3"
   },
   "main": "lib/index.js",
   "bin": "bin/minijn",

--- a/spec/failure_egs.js
+++ b/spec/failure_egs.js
@@ -24,3 +24,11 @@ describe('timeouts', function() {
     expect(1 + 2).toEqual(3);
   });
 });
+
+describe('manual failure', function() {
+  it('should fail manually (THIS IS EXPECTED)', function(done) {
+    setTimeout(function() {
+      done.fail('Error');
+    }, 10);
+  });
+});

--- a/spec/sample_spec.js
+++ b/spec/sample_spec.js
@@ -7,9 +7,8 @@ describe('mini-jasmine-node', function() {
   it('shows asynchronous test node-style', function(done) {
     setTimeout(function() {
       expect('second').toEqual('second');
-      // If you call done() with an argument, it will fail the spec 
+      // If you call done.fail(), it will fail the spec
       // so you can use it as a handler for many async node calls
-      // TODO - fix this.
       done();
     }, 10);
     expect('first').toEqual('first');

--- a/specs.sh
+++ b/specs.sh
@@ -18,5 +18,5 @@ echo "These should be examples of failing tests"
 command="${entry} spec/failure_egs.js spec/syntax_error.js --forceexit"
 echo $command
 time $command #/nested/uber-nested
-echo -e "\033[1;35m--- Should have 5 specs, 3 failures ---\033[0m"
+echo -e "\033[1;35m--- Should have 6 specs, 4 failures ---\033[0m"
 echo ""


### PR DESCRIPTION
Adds timeouts, before/afterAll, jasmine/done.fail(), and native featured specs.
