### PR TITLE
Better error message when matching null/undefined with toContain.

### DIFF
--- a/lib/jasmine-1.3.1.js
+++ b/lib/jasmine-1.3.1.js
@@ -1108,6 +1108,9 @@ jasmine.Env.prototype.equals_ = function(a, b, mismatchKeys, mismatchValues) {
 };
 
 jasmine.Env.prototype.contains_ = function(haystack, needle) {
+  if (hackstack == jasmine.null || haystack == jasmine.undefined) {
+    return false;
+  }
   if (jasmine.isArray_(haystack)) {
     for (var i = 0; i < haystack.length; i++) {
       if (this.equals_(haystack[i], needle)) return true;
@@ -1562,6 +1565,11 @@ jasmine.Matchers.prototype.wasNotCalledWith = function() {
  * @param {Object} expected
  */
 jasmine.Matchers.prototype.toContain = function(expected) {
+  this.message = function() {
+    var normalMessage = 'Expected ' + jasmine.pp(this.actual) + ' to contain ' + jasmine.pp(expected) + '.';
+    var invertedMessage = 'Expected ' + jasmine.pp(this.actual) + ' not to contain ' + jasmine.pp(expected) + '.';
+    return [normalMessage, invertedMessage];
+  };
   return this.env.contains_(this.actual, expected);
 };
 

--- a/lib/jasmine-1.3.1.js
+++ b/lib/jasmine-1.3.1.js
@@ -1108,7 +1108,7 @@ jasmine.Env.prototype.equals_ = function(a, b, mismatchKeys, mismatchValues) {
 };
 
 jasmine.Env.prototype.contains_ = function(haystack, needle) {
-  if (hackstack == jasmine.null || haystack == jasmine.undefined) {
+  if (haystack == jasmine.null || haystack == jasmine.undefined) {
     return false;
   }
   if (jasmine.isArray_(haystack)) {


### PR DESCRIPTION
I was recently thrown off by the error message 

```
minijasminenode/lib/jasmine-1.3.1.js:1142
  return haystack.indexOf(needle) >= 0;
                  ^
TypeError: Cannot call method 'indexOf' of null
```

Since this happened when running a pretty large test suite, I was not immediately sure what had happened, nor which test case had actually failed. After some debugging it turned out that I had called expect(foo).toContain(bar), where foo was null. This pull request provides a better error message in this case:

```
Failures:

  1) toContain should print helpful error message when matching null
   Message:
     Expected null to contain 'needle'.
   Stacktrace:
     Error: Expected null to contain 'needle'.
    at null.<anonymous> (.../minijasminenode/spec/tocontain_spec.js:3:18)
```

I am not sure this is the correct repo to fix this in. 
I also did not find any unit tests for the matchers, so I was not sure if I should add one for this change.
Please advice. 
